### PR TITLE
to see the reauthentication option again

### DIFF
--- a/ghost/admin/tests/acceptance/authentication-test.js
+++ b/ghost/admin/tests/acceptance/authentication-test.js
@@ -171,7 +171,11 @@ describe('Acceptance: Authentication', function () {
                 metaKey: ctrlOrCmd === 'command',
                 ctrlKey: ctrlOrCmd === 'ctrl'
             });
-
+            
+            
+      // to see teh re-authentication model
+            expect(findAll('.fullscreen-modal #login').length, 'modal exists').to.equal(1);
+        });
       
 
         // don't clobber debounce/throttle for future tests


### PR DESCRIPTION
from editing into tab 1 after logging out from tab2

even after logging out from tab2we can edit and sav in tab1 after reauthenticating avoiding regression in the re-authentivate modal

    ```
  // we should see a re-auth modal
            expect(findAll('.fullscreen-modal #login').length, 'modal exists').to.equal(1);
        });- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

```
We appreciate your contribution!

Also, if you'd be interested in writing code like this for us more regularly, we're hiring:
https://careers.ghost.org
